### PR TITLE
Firebaseの保存先などを修正

### DIFF
--- a/App/src/scenes/End.js
+++ b/App/src/scenes/End.js
@@ -4,11 +4,43 @@ import CameraRollExtended from 'react-native-store-photos-album';
 import { Button, Text, View } from 'native-base';
 import styled from 'styled-components';
 import { Actions } from 'react-native-router-flux';
+import * as firebase from 'firebase';
 import { Layout } from '../components/';
 
 const image = '../../img/Bitmap3.png';
 
 export default class End extends Component {
+  constructor() {
+    super();
+    this.state = {
+      isLoad: false,
+      name: '旅のハッシュタグ'
+    }
+  }
+
+  componentWillMount = async() => {
+    const { hashtagId  } = this.props;
+    this.setState({ isLoad: true })
+    try {
+      const snapshot = await firebase.database().ref(`/hashtags/${hashtagId}`).once('value');
+      this.setState({
+        name: snapshot.val().content,
+        isLoad: false
+      })
+    } catch(err) {
+      console.log(err);
+      this.setState({ isLoad: false })
+      Alert.alert(
+        'APIを叩く際にエラーが発生しました。',
+        '',
+        [{
+          text: 'OK',
+          onPress: () => console.log(err.toString())
+        },],
+        { cancelable: false }
+      )
+    }
+  }
 
   // 画像の保存
   onPressSave() {

--- a/App/src/scenes/Record.js
+++ b/App/src/scenes/Record.js
@@ -49,11 +49,13 @@ export default class Record extends Component {
   };
 
   writeLocationToFirebase(location) {
-    firebase.database().ref("/hashtags/" + this.props.hashtagId + "/coodinates").push({
-      latitude: location.coords.latitude,
-      longitude: location.coords.longitude,
-      timestamp: moment().format()
-    });
+    firebase.database()
+      .ref("/hashtags/" + this.props.hashtagId + "/coordinates")
+      .push({
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+        timestamp: moment().format()
+      });
   }
 
   onPressButton() {

--- a/App/src/scenes/Record.js
+++ b/App/src/scenes/Record.js
@@ -89,8 +89,9 @@ export default class Record extends Component {
 
   onPressCancelButton() {
     if (this.state.intervalId == null) {
+      // 3分ごとに位置情報をfirebaseへ送る
       this.setState({
-        intervalId: setInterval(this.getLocationAsync, 3000),
+        intervalId: setInterval(this.getLocationAsync, 180000),
         buttonName: '一時停止',
         status: true
       });

--- a/App/src/scenes/Record.js
+++ b/App/src/scenes/Record.js
@@ -49,9 +49,10 @@ export default class Record extends Component {
   };
 
   writeLocationToFirebase(location) {
-    firebase.database().ref("coodinates/" + moment().format()).set({
+    firebase.database().ref("/hashtags/" + this.props.hashtagId).push({
       latitude: location.coords.latitude,
-      longitude: location.coords.longitude
+      longitude: location.coords.longitude,
+      timestamp: moment().format()
     });
   }
 

--- a/App/src/scenes/Record.js
+++ b/App/src/scenes/Record.js
@@ -49,7 +49,7 @@ export default class Record extends Component {
   };
 
   writeLocationToFirebase(location) {
-    firebase.database().ref("/hashtags/" + this.props.hashtagId).push({
+    firebase.database().ref("/hashtags/" + this.props.hashtagId + "/coodinates").push({
       latitude: location.coords.latitude,
       longitude: location.coords.longitude,
       timestamp: moment().format()

--- a/App/src/scenes/Record.js
+++ b/App/src/scenes/Record.js
@@ -57,6 +57,7 @@ export default class Record extends Component {
   }
 
   onPressButton() {
+    const { hashtagId } = this.props;
     clearInterval(this.state.intervalId);
     this.setState({
       intervalId: null,
@@ -69,12 +70,12 @@ export default class Record extends Component {
       .then(
         res => {
           console.log(res.data);
-          Actions.end();
+          Actions.end({ hashtagId });
         })
       .catch(
         err => {
           console.log(err.request);
-          Actions.end();
+          Actions.end({ hashtagId });
           // Alert.alert(
           //   'APIを叩く際にエラーが発生しました。',
           //   '',

--- a/App/src/scenes/Record.js
+++ b/App/src/scenes/Record.js
@@ -26,8 +26,9 @@ export default class Record extends Component {
         locationErrorMessage: 'Oops, this will not work on Sketch in an Android emulator. Try it on your device!',
       });
     } else {
+      // 3分ごとに位置情報をfirebaseへ送る
       this.setState({
-        intervalId: setInterval(this.getLocationAsync, 3000),
+        intervalId: setInterval(this.getLocationAsync, 180000),
         status: true
       });
     }

--- a/App/src/scenes/Start.js
+++ b/App/src/scenes/Start.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Actions } from 'react-native-router-flux';
 import * as firebase from 'firebase';
 import { Image } from 'react-native';
+import { FIREBASE_DATABASE_URL } from 'react-native-dotenv'
 import { View, Content, Input, Button, Text } from 'native-base';
 import styled from 'styled-components';
 import { Layout } from '../components/';
@@ -14,9 +15,16 @@ export default class Start extends Component {
     };
   }
 
-  submitText = text => {
-    firebase.database().ref("/hashtags").push(text);
-    Actions.record();
+  submitText = async(text) => {
+    // オブジェクト型でハッシュタグを保存し保存先のURLを取得
+    const hashtagUrl = await firebase.database().ref("/hashtags").push(text);
+    const hashtagId = await this.getHashtagId(hashtagUrl)
+    Actions.record({ hashtagId }); // 記録画面へidを渡す
+  }
+
+  getHashtagId = hashtagUrl => {
+    const url = FIREBASE_DATABASE_URL + "/hashtags/"
+    return hashtagUrl.toString().replace(url, '');
   }
 
   render() {

--- a/App/src/scenes/Start.js
+++ b/App/src/scenes/Start.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { Actions } from 'react-native-router-flux';
 import * as firebase from 'firebase';
 import { Image } from 'react-native';
-import { FIREBASE_DATABASE_URL } from 'react-native-dotenv'
 import { View, Content, Input, Button, Text } from 'native-base';
 import styled from 'styled-components';
 import { Layout } from '../components/';
@@ -18,13 +17,7 @@ export default class Start extends Component {
   submitText = async(text) => {
     // オブジェクト型でハッシュタグを保存し保存先のURLを取得
     const hashtagUrl = await firebase.database().ref("/hashtags").push({content: text});
-    const hashtagId = await this.getHashtagId(hashtagUrl)
-    Actions.record({ hashtagId }); // 記録画面へidを渡す
-  }
-
-  getHashtagId = hashtagUrl => {
-    const url = FIREBASE_DATABASE_URL + "/hashtags/"
-    return hashtagUrl.toString().replace(url, '');
+    Actions.record({ hashtagId: hashtagUrl.key }); // 記録画面へidを渡す
   }
 
   render() {

--- a/App/src/scenes/Start.js
+++ b/App/src/scenes/Start.js
@@ -14,8 +14,8 @@ export default class Start extends Component {
     };
   }
 
-  submitText = () => {
-    firebase.database().ref("/hashtags").set({text: this.state.hashtag});
+  submitText = text => {
+    firebase.database().ref("/hashtags").push(text);
     Actions.record();
   }
 
@@ -36,7 +36,7 @@ export default class Start extends Component {
           </Tag>
           <StyledButton
             full
-            onPress={() => this.submitText()}
+            onPress={() => this.submitText(hashtag)}
           >
             <Text>このタグで出発</Text>
           </StyledButton>

--- a/App/src/scenes/Start.js
+++ b/App/src/scenes/Start.js
@@ -17,7 +17,7 @@ export default class Start extends Component {
 
   submitText = async(text) => {
     // オブジェクト型でハッシュタグを保存し保存先のURLを取得
-    const hashtagUrl = await firebase.database().ref("/hashtags").push(text);
+    const hashtagUrl = await firebase.database().ref("/hashtags").push({content: text});
     const hashtagId = await this.getHashtagId(hashtagUrl)
     Actions.record({ hashtagId }); // 記録画面へidを渡す
   }


### PR DESCRIPTION
### 背景
- 単一ではできたが複数回(またはユーザー)が利用する時にデータを関連付けて引っ張ってこれない

### 変更点

```
- hashtags
  - id: ユニークなIDを持つオブジェクト
    - content: ハッシュタグ名
    - coordinates: 座標の配列
      - id: ユニークなIDを持つオブジェクト(複数)
        - latitude: 緯度
        - longitude: 経度
        - timestamp: 作成時間
      - id
        - latitude
        - longitude
        - timestamp
...(略)
```
のようなスキーマに変更

- (念の為)最後の画面でハッシュタグ名を取得できるようにした

- 位置情報取得の間隔が3秒だと取りすぎたので一旦3分に変更